### PR TITLE
remove explicit `@babel/plugin-proposal-class-properties`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = (context, opts = {}) => ({
     require.resolve('babel-plugin-react-require'),
     require.resolve('@babel/plugin-syntax-dynamic-import'),
     [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-    [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
     [
       require.resolve('@babel/plugin-transform-runtime'),
       {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "homepage": "https://github.com/cuining/babel-preset-next#readme",
   "main": "index.js",
   "dependencies": {
-    "@babel/plugin-proposal-decorators": "^7.0.0",
-    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "@babel/preset-react": "^7.0.0",
-    "babel-plugin-react-require": "^3.0.0"
+    "@babel/plugin-proposal-decorators": "^7.10.1",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.10.1",
+    "@babel/preset-env": "^7.10.2",
+    "@babel/preset-react": "^7.10.1",
+    "babel-plugin-react-require": "^3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-next",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "babel preset used by myself",
   "repository": {
     "type": "git",
@@ -14,7 +14,6 @@
   "homepage": "https://github.com/cuining/babel-preset-next#readme",
   "main": "index.js",
   "dependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",


### PR DESCRIPTION
## remove explicit `@babel/plugin-proposal-class-properties` and let `@babel/preset-env` add it

根据这个[链接](https://github.com/babel/babel/issues/11622#issuecomment-634390210)，当`shippedProposals`设置为`true`时，`@babel/plugin-proposal-class-properties`和`@babel/plugin-proposal-private-methods`会被默认引入，所以这里剔除了。

